### PR TITLE
Rename workflows to branch/main/tag naming convention

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -1,7 +1,8 @@
-name: ci
+name: branch
 
 on:
-  push: {}
+  push:
+    branches-ignore: [main]
   workflow_dispatch: {}
 
 permissions:
@@ -12,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-    - uses: wtnb75/actions/golang@c1711251ea69e3e6d68db7a9fa019d79b497f70c # v1.0.3
-    - uses: wtnb75/actions/gotest@c1711251ea69e3e6d68db7a9fa019d79b497f70c # v1.0.3
+    - uses: wtnb75/actions/golang@v1
+    - uses: wtnb75/actions/gotest@v1
 
   docker:
     needs: test
@@ -23,7 +24,7 @@ jobs:
       packages: write
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-    - uses: wtnb75/actions/docker@c1711251ea69e3e6d68db7a9fa019d79b497f70c # v1.0.3
+    - uses: wtnb75/actions/docker@v1
       with:
         push: 'true'
         context: .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,57 @@
+name: main
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: wtnb75/actions/golang@v1
+    - uses: wtnb75/actions/gotest@v1
+      with:
+        html-output-dir: coverage
+    - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      with:
+        enable-cache: false
+    - uses: wtnb75/actions/merge-pages@v1
+      with:
+        dirs: "coverage"
+    - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+  docker:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: wtnb75/actions/docker@v1
+      with:
+        push: 'true'
+        context: .
+        file: Dockerfile.branch
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+  deploy:
+    needs: build
+    if: github.ref_name == 'main'
+    permissions:
+      pages: write
+      id-token: write
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - name: deploy pages
+      id: deployment
+      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,4 +1,4 @@
-name: release
+name: tag
 
 on:
   push:


### PR DESCRIPTION
Aligns this repo's workflow naming with the convention already established across the account's other repos (Python/TypeScript/Rust/Dart-Flutter phases, and specifically `wtnb75/intarray`).

## Changes
- `ci.yml` -> `branch.yml`: trigger changed from `push: {}` to `push: {branches-ignore: [main]}` + `workflow_dispatch`. Action refs switched from hand-pinned SHAs to floating `@v1` tags (matches convention for newly-authored workflow files; re-pinned later by the repo owner's own `pinact run -u` tooling).
- New `main.yml`: runs on push to `main` (+ `workflow_dispatch`). Builds/tests, publishes a Go coverage HTML report to GitHub Pages via `merge-pages`/`configure-pages`/`deploy-pages`, and builds+pushes the `docker` image (mirrors `branch.yml`'s docker job).
- `release.yml` -> `tag.yml`: only the `name:` field changed (`release` -> `tag`). The existing `docker/setup-buildx-action` + `docker/login-action` steps before `goreleaser-action` (specific to this repo's release process) are preserved as-is.
- `update-deps.yml` untouched.

## CI verification
- `branch.yml` ran green on this branch's push (test + docker jobs): https://github.com/wtnb75/uhd/actions/runs/30726039188
- `main.yml` was verified on a throwaway branch (since `workflow_dispatch` can't target a workflow that isn't yet registered on the default branch). It fails as expected at the `merge-pages` step (`cp: cannot stat 'coverage': No such file or directory`), because the `gotest` composite action's currently-tagged `v1` doesn't yet support the `html-output-dir` input it's called with (`Unexpected input(s) 'html-output-dir', valid inputs are ['tags']`). This is a known, accepted precondition: [wtnb75/actions#61](https://github.com/wtnb75/actions/pull/61) adds that input and has been merged to `main`, but the `v1` tag hasn't been moved past it yet. `main.yml` will go green once `v1` is retagged.

GitHub Pages is already configured for this repo (`build_type: workflow`), so no separate Pages-enablement step is needed — `main.yml`'s `deploy` job will work once the above precondition clears.