### PR TITLE
add --version flag

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,6 +18,10 @@ builds:
       - amd64
       - arm64
       - wasm
+    ldflags:
+      - -X main.version={{ .Version }}
+      - -X main.commit={{ .ShortCommit }}
+      - -X main.date={{ .Date }}
 
 dockers:
   - image_templates:

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ var option struct {
 	NoColor      bool   `long:"no-color" description:"disable color output"`
 	InstallSkill bool   `long:"install-skill" description:"install Copilot skill to user skill directory"`
 	SkillTarget  string `long:"skill-target" default:"copilot" choice:"copilot" choice:"agents" choice:"claude" description:"target skill directory (~/.copilot, ~/.agents, ~/.claude)"`
+	Version      bool   `short:"V" long:"version" description:"show version and exit"`
 }
 
 type column struct {
@@ -151,6 +152,10 @@ func main() {
 	parser := flags.NewParser(&option, flags.Default)
 	parsed, err := parser.Parse()
 	if err != nil {
+		return
+	}
+	if option.Version {
+		fmt.Println("uhd", version, "hash", commit, "build", date)
 		return
 	}
 	if option.InstallSkill {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestVersionFlag(t *testing.T) {
+	oldArgs := os.Args
+	oldStdout := os.Stdout
+	oldOption := option
+	defer func() {
+		os.Args = oldArgs
+		os.Stdout = oldStdout
+		option = oldOption
+	}()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal("pipe", err)
+	}
+	os.Stdout = w
+	os.Args = []string{"uhd", "--version"}
+
+	main()
+
+	if err := w.Close(); err != nil {
+		t.Error("write close", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Error("read", err)
+	}
+
+	if !strings.Contains(string(out), "uhd") {
+		t.Error("missing command name", string(out))
+	}
+	if !strings.Contains(string(out), version) {
+		t.Error("missing version", string(out))
+	}
+	if !strings.Contains(string(out), commit) {
+		t.Error("missing commit", string(out))
+	}
+	if !strings.Contains(string(out), date) {
+		t.Error("missing date", string(out))
+	}
+}

--- a/version.go
+++ b/version.go
@@ -1,0 +1,7 @@
+package main
+
+var (
+	version = "dev"
+	commit  = "dummy_hash"
+	date    = "dummy_date"
+)


### PR DESCRIPTION
## Background
Part of a fleet-wide sweep for tag→version reflection (see wtnb75/httpcgi#129, wtnb75/ziphttp#100). Unlike those two, uhd had no version-reporting mechanism at all.

## Fix
uhd is a flat-flag CLI (no subcommands), so this follows httpcgi's pattern instead: a `-V`/`--version` bool flag on the top-level option struct, printed before any other logic runs. `version`/`commit`/`date` vars wired via goreleaser `ldflags`.

## Verification
- `gofmt`, `go vet`, `go test ./...`, `golangci-lint run ./...` all clean
- `goreleaser build --snapshot --clean --single-target` locally: `./uhd --version` → `uhd feat/add-version-command hash 5a9230e build <timestamp>` (real values, not placeholders)
- `branch` workflow green: https://github.com/wtnb75/uhd/actions/runs/30810569588
- Full `tag.yml` release-path verification requires an actual `v*` tag push, left for a real release per project convention.